### PR TITLE
Add MacOS Build Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ cabal.sandbox.config
 .DS_Store
 *~
 travis.log
+dist-newstyle
+cabal.project.local

--- a/cabal.config
+++ b/cabal.config
@@ -1,2 +1,3 @@
 profiling: False
 library-profiling: True
+overwrite-policy: always

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+with-compiler: ghc-9.0.2
+packages: .

--- a/elm.cabal
+++ b/elm.cabal
@@ -23,6 +23,18 @@ Category: Compiler, Language
 Cabal-version: >=1.9
 Build-type: Simple
 
+Data-files:
+    reactor/elm.json
+    reactor/check.py
+    reactor/src/*.elm
+    reactor/src/Index/*.elm
+    reactor/src/mock.txt
+    reactor/assets/favicon.ico
+    reactor/assets/styles.css
+    reactor/assets/source-sans-pro.ttf
+    reactor/assets/source-code-pro.ttf
+
+
 source-repository head
     type:     git
     location: git://github.com/elm/compiler.git

--- a/installers/mac/README.md
+++ b/installers/mac/README.md
@@ -73,6 +73,45 @@ So the point of running `sudo mv elm /usr/local/bin/` is to turn the `elm` binar
 
 <br/>
 
+## Installing from Source
+
+First, install ghcup in homebrew (or you may manage your own ghc compiler):
+
+```sh
+> brew install ghcup
+```
+
+Then set the following versions:
+
+```sh
+> ghcup set ghc 9.0.2
+> ghcup install cabal
+```
+
+You may need to ensure a proper link to llvm@13. Run:
+
+```sh
+brew install llvm@13
+```
+
+and then in the `ash-compiler` root directory, run:
+
+```
+echo "program-options\n  ghc-options: \"$(pkg-config --cflags libffi)\"" > cabal.project.local
+```
+
+Now you should be able to build with:
+
+```
+cabal build elm
+```
+
+And you can install the elm executable via:
+
+```
+cabal install elm --overwrite-policy=always
+```
+
 ## Uninstall
 
 The following commands should remove everything:


### PR DESCRIPTION
Here we add detailed build instructions to make it possible to build the ash compiler on MacOS from source using `ghcup` and `cabal`. There are a number of small changes, but they are necessary for a proper build. We document this in a new section of the MacOS README for Ash.

Note, due to [this issue](https://github.com/haskell/cabal/issues/5942) it looks like `overwrite-policy` in `cabal.config` is being ignored, and thus we add it to the install command for the user for the time-being.
