### PR TITLE
Massive Debugging

### DIFF
--- a/builder/src/Build.hs
+++ b/builder/src/Build.hs
@@ -15,6 +15,9 @@ module Build
   where
 
 
+import Debug.Trace
+
+
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
 import Control.Monad (filterM, mapM_, sequence_)
@@ -303,15 +306,20 @@ crawlModule env@(Env _ root projectType srcDirs buildID locals foreigns) mvar do
 
             Nothing ->
               if Name.isKernel name && Parse.isKernel projectType then
-                do  exists <- File.exists ("src" </> ModuleName.toFilePath name <.> "js")
-                    return $ if exists then SKernel else SBadImport Import.NotFound
+                do  let path = "src" </> ModuleName.toFilePath name <.> "js"
+                    let path_ = trace ("path="++path) path
+                    exists <- File.exists path_
+                    let exists_ = trace ("exists="++show exists) exists
+                    return $ if exists_ then SKernel else SBadImport Import.NotFound
               else
                 return $ SBadImport Import.NotFound
 
 
 crawlFile :: Env -> MVar StatusDict -> DocsNeed -> ModuleName.Raw -> FilePath -> File.Time -> Details.BuildID -> IO Status
 crawlFile env@(Env _ root projectType _ buildID _ _) mvar docsNeed expectedName path time lastChange =
-  do  source <- File.readUtf8 (root </> path)
+  do  let fullPath = (root </> path)
+      let fullPath_ = trace ("fullPath=" <> fullPath) fullPath
+      source <- File.readUtf8 fullPath_
 
       case Parse.fromByteString projectType source of
         Left err ->

--- a/builder/src/Elm/Details.hs
+++ b/builder/src/Elm/Details.hs
@@ -389,7 +389,7 @@ type Dep =
 verifyDep :: Env -> MVar (Map.Map Pkg.Name (MVar Dep)) -> Map.Map Pkg.Name Solver.Details -> Pkg.Name -> Solver.Details -> IO Dep
 verifyDep (Env key _ _ cache manager _ _) depsMVar solution pkg details@(Solver.Details vsn directDeps) =
   do  let fingerprint = Map.intersectionWith (\(Solver.Details v _) _ -> v) solution directDeps
-      exists <- Dir.doesDirectoryExist (Stuff.package cache pkg vsn </> "src")
+      exists <- Dir.doesDirectoryExist (Stuff.package cache (traceShow ("verifyDep1330", pkg) pkg) vsn </> "src")
       if exists
         then
           do  Reporting.report key Reporting.DCached
@@ -504,7 +504,7 @@ gatherObjects results =
 
 addLocalGraph :: ModuleName.Raw -> Result -> Opt.GlobalGraph -> Opt.GlobalGraph
 addLocalGraph name status graph =
-  case status of
+  case (traceShow ("addLocalGraph", name, status) status) of
     RLocal _ objs _ -> Opt.addLocalGraph objs graph
     RForeign _      -> graph
     RKernelLocal cs -> Opt.addKernel (Name.getKernel name) (Name.isCoreMod name) cs graph
@@ -660,6 +660,7 @@ data Result
   | RForeign I.Interface
   | RKernelLocal [Kernel.Chunk]
   | RKernelForeign
+  deriving (Show)
 
 
 compile :: Pkg.Name -> MVar (Map.Map ModuleName.Raw (MVar (Maybe Result))) -> Status -> IO (Maybe Result)

--- a/builder/src/Elm/Details.hs
+++ b/builder/src/Elm/Details.hs
@@ -109,9 +109,14 @@ data Local =
     , _lastCompile :: BuildID
     }
 
+instance Show Local where 
+  show (Local path _ deps main lastChange lastCompile) =
+    "Local " ++ show path ++ show deps ++ show main ++ show lastChange ++ show lastCompile
+
 
 data Foreign =
   Foreign Pkg.Name [Pkg.Name]
+  deriving (Show)
 
 
 data Extras
@@ -705,6 +710,7 @@ getInterface result =
 data DocsStatus
   = DocsNeeded
   | DocsNotNeeded
+  deriving (Show)
 
 
 getDocsStatus :: Stuff.PackageCache -> Pkg.Name -> V.Version -> IO DocsStatus

--- a/builder/src/Generate.hs
+++ b/builder/src/Generate.hs
@@ -8,6 +8,9 @@ module Generate
   where
 
 
+import Debug.Trace
+
+
 import Prelude hiding (cycle, print)
 import Control.Concurrent (MVar, forkIO, newEmptyMVar, newMVar, putMVar, readMVar)
 import Control.Monad (liftM2)
@@ -136,7 +139,7 @@ loadObjects root details modules =
 
 loadObject :: FilePath -> Build.Module -> IO (ModuleName.Raw, MVar (Maybe Opt.LocalGraph))
 loadObject root modul =
-  case modul of
+  case trace ("zz loadObject:" ++ show modul) modul of
     Build.Fresh name _ graph ->
       do  mvar <- newMVar (Just graph)
           return (name, mvar)

--- a/cabal.config
+++ b/cabal.config
@@ -1,3 +1,3 @@
-profiling: False
+profiling: True
 library-profiling: True
 overwrite-policy: always

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
 with-compiler: ghc-9.0.2
 packages: .
 optimization: 0
+profiling: True

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
 with-compiler: ghc-9.0.2
 packages: .
+optimization: 0

--- a/compiler/src/AST/Canonical.hs
+++ b/compiler/src/AST/Canonical.hs
@@ -105,15 +105,15 @@ data Expr_
   | Unit
   | Tuple Expr Expr (Maybe Expr)
   | Shader Shader.Source Shader.Types
-
+  deriving (Show)
 
 data CaseBranch =
   CaseBranch Pattern Expr
-
+  deriving (Show)
 
 data FieldUpdate =
   FieldUpdate A.Region Expr
-
+  deriving (Show)
 
 
 -- DEFS
@@ -122,7 +122,7 @@ data FieldUpdate =
 data Def
   = Def (A.Located Name) [Pattern] Expr
   | TypedDef (A.Located Name) FreeVars [(Pattern, Type)] Expr Type
-
+  deriving (Show)
 
 
 -- DECLARATIONS
@@ -132,7 +132,7 @@ data Decls
   = Declare Def Decls
   | DeclareRec Def [Def] Decls
   | SaveTheEnvironment
-
+  deriving (Show)
 
 
 -- PATTERNS
@@ -167,7 +167,7 @@ data Pattern_
       -- CACHE _p_index to replace _p_name in PROD code gen
       -- CACHE _p_opts to allocate less in PROD code gen
       -- CACHE _p_alts and _p_numAlts for exhaustiveness checker
-
+  deriving (Show)
 
 data PatternCtorArg =
   PatternCtorArg
@@ -175,6 +175,7 @@ data PatternCtorArg =
     , _type :: Type             -- CACHE for type inference
     , _arg :: Pattern
     }
+  deriving (Show)
 
 
 
@@ -182,7 +183,7 @@ data PatternCtorArg =
 
 
 data Annotation = Forall FreeVars Type
-  deriving (Eq)
+  deriving (Eq, Show)
 
 
 type FreeVars = Map.Map Name ()
@@ -196,17 +197,17 @@ data Type
   | TUnit
   | TTuple Type Type (Maybe Type)
   | TAlias ModuleName.Canonical Name [(Name, Type)] AliasType
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data AliasType
   = Holey Type
   | Filled Type
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data FieldType = FieldType {-# UNPACK #-} !Word16 Type
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 -- NOTE: The Word16 marks the source order, but it may not be available
@@ -240,14 +241,15 @@ data Module =
     , _binops  :: Map.Map Name Binop
     , _effects :: Effects
     }
+  deriving (Show)
 
 
 data Alias = Alias [Name] Type
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data Binop = Binop_ Binop.Associativity Binop.Precedence Name
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data Union =
@@ -257,18 +259,18 @@ data Union =
     , _u_numAlts :: Int -- CACHE numAlts for exhaustiveness checking
     , _u_opts :: CtorOpts -- CACHE which optimizations are available
     }
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data CtorOpts
   = Normal
   | Enum
   | Unbox
-  deriving (Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 
 data Ctor = Ctor Name Index.ZeroBased Int [Type] -- CACHE length args
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 
@@ -278,7 +280,7 @@ data Ctor = Ctor Name Index.ZeroBased Int [Type] -- CACHE length args
 data Exports
   = ExportEverything A.Region
   | Export (Map.Map Name (A.Located Export))
-
+  deriving (Show)
 
 data Export
   = ExportValue
@@ -287,7 +289,7 @@ data Export
   | ExportUnionOpen
   | ExportUnionClosed
   | ExportPort
-
+  deriving (Show)
 
 
 -- EFFECTS
@@ -297,18 +299,18 @@ data Effects
   = NoEffects
   | Ports (Map.Map Name Port)
   | Manager A.Region A.Region A.Region Manager
-
+  deriving (Show)
 
 data Port
   = Incoming { _freeVars :: FreeVars, _payload :: Type, _func :: Type }
   | Outgoing { _freeVars :: FreeVars, _payload :: Type, _func :: Type }
-
+  deriving (Show)
 
 data Manager
   = Cmd Name
   | Sub Name
   | Fx Name Name
-
+  deriving (Show)
 
 
 -- BINARY

--- a/compiler/src/AST/Optimized.hs
+++ b/compiler/src/AST/Optimized.hs
@@ -21,6 +21,9 @@ module AST.Optimized
   where
 
 
+import Debug.Trace
+
+
 import Control.Monad (liftM, liftM2, liftM3, liftM4)
 import Data.Binary (Binary, get, put, getWord8, putWord8)
 import qualified Data.Map as Map
@@ -72,9 +75,10 @@ data Expr
   | Unit
   | Tuple Expr Expr (Maybe Expr)
   | Shader Shader.Source (Set.Set Name) (Set.Set Name)
-
+  deriving (Show)
 
 data Global = Global ModuleName.Canonical Name
+  deriving (Show)
 
 
 
@@ -84,18 +88,18 @@ data Global = Global ModuleName.Canonical Name
 data Def
   = Def Name Expr
   | TailDef Name [Name] Expr
-
+  deriving (Show)
 
 data Destructor =
   Destructor Name Path
-
+  deriving (Show)
 
 data Path
   = Index Index.ZeroBased Path
   | Field Name Path
   | Unbox Path
   | Root Name
-
+  deriving (Show)
 
 
 -- BRANCHING
@@ -113,13 +117,13 @@ data Decider a
       , _tests :: [(DT.Test, Decider a)]
       , _fallback :: Decider a
       }
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data Choice
   = Inline Expr
   | Jump Int
-
+  deriving (Show)
 
 
 -- OBJECT GRAPH
@@ -160,10 +164,11 @@ data Node
   | Kernel [K.Chunk] (Set.Set Global)
   | PortIncoming Expr (Set.Set Global)
   | PortOutgoing Expr (Set.Set Global)
+  deriving (Show)
 
 
 data EffectsType = Cmd | Sub | Fx
-
+  deriving (Show)
 
 
 -- GRAPHS
@@ -191,11 +196,11 @@ addLocalGraph (LocalGraph _ nodes1 fields1) (GlobalGraph nodes2 fields2) =
     }
 
 
-addKernel :: Name.Name -> [K.Chunk] -> GlobalGraph -> GlobalGraph
-addKernel shortName chunks (GlobalGraph nodes fields) =
+addKernel :: Name.Name -> Bool -> [K.Chunk] -> GlobalGraph -> GlobalGraph
+addKernel shortName isCoreMod chunks (GlobalGraph nodes fields) =
   let
-    global = toKernelGlobal shortName
-    node = Kernel chunks (foldr addKernelDep Set.empty chunks)
+    global = toKernelGlobal shortName isCoreMod
+    node = Kernel chunks (foldr (addKernelDep isCoreMod) Set.empty chunks)
   in
   GlobalGraph
     { _g_nodes = Map.insert global node nodes
@@ -203,12 +208,12 @@ addKernel shortName chunks (GlobalGraph nodes fields) =
     }
 
 
-addKernelDep :: K.Chunk -> Set.Set Global -> Set.Set Global
-addKernelDep chunk deps =
+addKernelDep :: Bool -> K.Chunk -> Set.Set Global -> Set.Set Global
+addKernelDep isCoreMod chunk deps =
   case chunk of
     K.JS _              -> deps
     K.ElmVar home name  -> Set.insert (Global home name) deps
-    K.JsVar shortName _ -> Set.insert (toKernelGlobal shortName) deps
+    K.JsVar shortName _ -> Set.insert (toKernelGlobal shortName isCoreMod) deps
     K.ElmField _        -> deps
     K.JsField _         -> deps
     K.JsEnum _          -> deps
@@ -216,10 +221,12 @@ addKernelDep chunk deps =
     K.Prod              -> deps
 
 
-toKernelGlobal :: Name.Name -> Global
-toKernelGlobal shortName =
-  Global (ModuleName.Canonical Pkg.kernel shortName) Name.dollar
-
+toKernelGlobal :: Name.Name -> Bool -> Global
+toKernelGlobal shortName isCoreMod =
+  if traceShow ("toKernelGlobal", shortName, isCoreMod) isCoreMod then
+    Global (ModuleName.Canonical Pkg.dummyName shortName) Name.dollar
+  else
+    Global (ModuleName.Canonical Pkg.kernel shortName) Name.dollar
 
 
 -- INSTANCES

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -118,6 +118,7 @@ data Type_
   | TRecord [(A.Located Name, Type)] (Maybe (A.Located Name))
   | TUnit
   | TTuple Type Type [Type]
+  deriving (Show)
 
 
 
@@ -169,19 +170,21 @@ data Value = Value (A.Located Name) [Pattern] Expr (Maybe Type)
 data Union = Union (A.Located Name) [A.Located Name] [(A.Located Name, [Type])]
 data Alias = Alias (A.Located Name) [A.Located Name] Type
 data Infix = Infix Name Binop.Associativity Binop.Precedence Name
-data Port = Port (A.Located Name) Type
+data Port = Port (A.Located Name) Type deriving (Show)
 
 
 data Effects
   = NoEffects
   | Ports [Port]
   | Manager A.Region Manager
+  deriving (Show)
 
 
 data Manager
   = Cmd (A.Located Name)
   | Sub (A.Located Name)
   | Fx (A.Located Name) (A.Located Name)
+  deriving (Show)
 
 
 data Docs
@@ -202,14 +205,17 @@ instance Show Comment where
 data Exposing
   = Open
   | Explicit [Exposed]
+  deriving (Show)
 
 
 data Exposed
   = Lower (A.Located Name)
   | Upper (A.Located Name) Privacy
   | Operator A.Region Name
+  deriving (Show)
 
 
 data Privacy
   = Public A.Region
   | Private
+  deriving (Show)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -139,7 +139,7 @@ data Module =
 
 
 instance Show Module where
-  show mod = "Module [" ++ (getName mod) ++ "]"
+  show mod = "Module [" ++ (Name.toChars (getName mod)) ++ "]"
 
 
 getName :: Module -> Name

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -138,6 +138,10 @@ data Module =
     }
 
 
+instance Show Module where
+  show mod = "Module [" ++ (getName mod) ++ "]"
+
+
 getName :: Module -> Name
 getName (Module maybeName _ _ _ _ _ _ _ _) =
   case maybeName of
@@ -183,11 +187,13 @@ data Manager
 data Docs
   = NoDocs A.Region
   | YesDocs Comment [(Name, Comment)]
-
+  deriving (Show)
 
 newtype Comment =
   Comment P.Snippet
 
+instance Show Comment where
+  show _ = "A comment"
 
 
 -- EXPOSING

--- a/compiler/src/AST/Utils/Binop.hs
+++ b/compiler/src/AST/Utils/Binop.hs
@@ -16,14 +16,14 @@ import Data.Binary
 
 
 newtype Precedence = Precedence Int
-  deriving (Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 
 data Associativity
   = Left
   | Non
   | Right
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 

--- a/compiler/src/AST/Utils/Shader.hs
+++ b/compiler/src/AST/Utils/Shader.hs
@@ -26,6 +26,8 @@ import qualified Data.Name as Name
 newtype Source =
   Source BS.ByteString
 
+instance Show Source where
+  show _ = "Shader Source"
 
 
 -- TYPES
@@ -39,6 +41,10 @@ data Types =
     }
 
 
+instance Show Types where
+  show _ = "Shader Types"
+
+
 data Type
   = Int
   | Float
@@ -48,6 +54,9 @@ data Type
   | M4
   | Texture
 
+
+instance Show Type where
+  show _ = "Shader Type"
 
 
 -- TO BUILDER

--- a/compiler/src/Compile.hs
+++ b/compiler/src/Compile.hs
@@ -82,6 +82,16 @@ nitpick canonical =
       Left (E.BadPatterns errors)
 
 
+-- loadKernel :: Src.Module -> Map.Map Name.Name Can.Annotation -> Can.Module -> Either E.Error Opt.LocalGraph
+-- optimize modul annotations canonical =
+--   case snd $ R.run $ Optimize.optimize annotations canonical of
+--     Right localGraph ->
+--       Right localGraph
+
+--     Left errors ->
+--       Left (E.BadMains (Localizer.fromModule modul) errors)
+
+
 optimize :: Src.Module -> Map.Map Name.Name Can.Annotation -> Can.Module -> Either E.Error Opt.LocalGraph
 optimize modul annotations canonical =
   case snd $ R.run $ Optimize.optimize annotations canonical of

--- a/compiler/src/Data/Index.hs
+++ b/compiler/src/Data/Index.hs
@@ -25,7 +25,7 @@ import Data.Binary
 
 
 newtype ZeroBased = ZeroBased Int
-  deriving (Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 
 first :: ZeroBased

--- a/compiler/src/Data/Name.hs
+++ b/compiler/src/Data/Name.hs
@@ -14,6 +14,7 @@ module Data.Name
   , hasDot
   , splitDots
   , isKernel
+  , isCoreMod
   , isNumberType
   , isComparableType
   , isAppendableType
@@ -65,6 +66,9 @@ import qualified Elm.String as ES
 
 type Name =
   Utf8.Utf8 ELM_NAME
+
+instance Show Name where
+  show = Utf8.toChars
 
 
 data ELM_NAME
@@ -159,7 +163,10 @@ getKernel name@(Utf8.Utf8 ba#) =
 
 
 isKernel :: Name -> Bool
-isKernel x = (Utf8.startsWith prefix_kernel x) || (Utf8.startsWith local_kernel x)
+isKernel x = (Utf8.startsWith prefix_kernel x) || isCoreMod x
+
+isCoreMod :: Name -> Bool
+isCoreMod x = Utf8.startsWith local_kernel x
 
 isNumberType :: Name -> Bool
 isNumberType = Utf8.startsWith prefix_number

--- a/compiler/src/Data/Name.hs
+++ b/compiler/src/Data/Name.hs
@@ -186,7 +186,7 @@ prefix_kernel = fromChars "Elm.Kernel."
 
 {-# NOINLINE local_kernel #-}
 local_kernel :: Name
-local_kernel = fromChars "AshCoreMod."
+local_kernel = fromChars "AshCoreMod"
 
 {-# NOINLINE prefix_number #-}
 prefix_number :: Name

--- a/compiler/src/Data/Name.hs
+++ b/compiler/src/Data/Name.hs
@@ -159,7 +159,7 @@ getKernel name@(Utf8.Utf8 ba#) =
 
 
 isKernel :: Name -> Bool
-isKernel = Utf8.startsWith prefix_kernel
+isKernel x = (Utf8.startsWith prefix_kernel x) || (Utf8.startsWith local_kernel x)
 
 isNumberType :: Name -> Bool
 isNumberType = Utf8.startsWith prefix_number
@@ -176,6 +176,10 @@ isCompappendType = Utf8.startsWith prefix_compappend
 {-# NOINLINE prefix_kernel #-}
 prefix_kernel :: Name
 prefix_kernel = fromChars "Elm.Kernel."
+
+{-# NOINLINE local_kernel #-}
+local_kernel :: Name
+local_kernel = fromChars "AshCoreMod."
 
 {-# NOINLINE prefix_number #-}
 prefix_number :: Name

--- a/compiler/src/Elm/Compiler/Type/Extract.hs
+++ b/compiler/src/Elm/Compiler/Type/Extract.hs
@@ -13,6 +13,9 @@ module Elm.Compiler.Type.Extract
   where
 
 
+import Debug.Trace
+
+
 import Data.Map ((!))
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
@@ -173,7 +176,7 @@ extractTransitive types (Deps seenAliases seenUnions) (Deps nextAliases nextUnio
 extractAlias :: Types -> Opt.Global -> Extractor T.Alias
 extractAlias (Types dict) (Opt.Global home name) =
   let
-    (Can.Alias args aliasType) = _alias_info (dict ! home) ! name
+    (Can.Alias args aliasType) = _alias_info (dict ! (trace ("extractAlias0:") home)) ! (trace ("extractAlias1:") name)
   in
   T.Alias (toPublicName home name) args <$> extract aliasType
 
@@ -185,7 +188,7 @@ extractUnion (Types dict) (Opt.Global home name) =
     else
       let
         pname = toPublicName home name
-        (Can.Union vars ctors _ _) = _union_info (dict ! home) ! name
+        (Can.Union vars ctors _ _) = _union_info (dict ! (trace ("extractUnion0:") home)) ! (trace ("extractUnion1:") name)
       in
       T.Union pname vars <$> traverse extractCtor ctors
 

--- a/compiler/src/Elm/Docs.hs
+++ b/compiler/src/Elm/Docs.hs
@@ -16,6 +16,8 @@ module Elm.Docs
   )
   where
 
+import Debug.Trace
+
 
 import qualified Data.Coerce as Coerce
 import qualified Data.List as List
@@ -497,26 +499,26 @@ checkExport info name (A.At region export) =
             m { _values = Map.insert name (Value comment tipe) (_values m) }
 
     Can.ExportBinop ->
-      do  let (Can.Binop_ assoc prec realName) = _iBinops info ! name
+      do  let (Can.Binop_ assoc prec realName) = _iBinops info ! (trace ("Can.ExportBinop") name)
           tipe <- getType realName info
           comment <- getComment region realName info
           Result.ok $ \m ->
             m { _binops = Map.insert name (Binop comment tipe assoc prec) (_binops m) }
 
     Can.ExportAlias ->
-      do  let (Can.Alias tvars tipe) = _iAliases info ! name
+      do  let (Can.Alias tvars tipe) = _iAliases info ! (trace ("Can.ExportAlias") name)
           comment <- getComment region name info
           Result.ok $ \m ->
             m { _aliases = Map.insert name (Alias comment tvars (Extract.fromType tipe)) (_aliases m) }
 
     Can.ExportUnionOpen ->
-      do  let (Can.Union tvars ctors _ _) = _iUnions info ! name
+      do  let (Can.Union tvars ctors _ _) = _iUnions info ! (trace ("Can.ExportUnionOpen") name)
           comment <- getComment region name info
           Result.ok $ \m ->
             m { _unions = Map.insert name (Union comment tvars (map dector ctors)) (_unions m) }
 
     Can.ExportUnionClosed ->
-      do  let (Can.Union tvars _ _ _) = _iUnions info ! name
+      do  let (Can.Union tvars _ _ _) = _iUnions info ! (trace ("Can.ExportUnionClosed") name)
           comment <- getComment region name info
           Result.ok $ \m ->
             m { _unions = Map.insert name (Union comment tvars []) (_unions m) }
@@ -540,7 +542,7 @@ getComment region name info =
 
 getType :: Name.Name -> Info -> Result.Result i w E.DefProblem Type.Type
 getType name info =
-  case _iValues info ! name of
+  case _iValues info ! (trace ("getType:") name) of
     Left region ->
       Result.throw (E.NoAnnotation name region)
 

--- a/compiler/src/Elm/Docs.hs
+++ b/compiler/src/Elm/Docs.hs
@@ -68,6 +68,10 @@ data Module =
     , _binops :: Map.Map Name.Name Binop
     }
 
+instance Show Module where
+  show (Module name _ unions aliases values binops) =
+    "Module " ++ show name ++ show unions ++ show aliases ++ show values ++ show binops
+
 type Comment = Json.String
 
 data Alias = Alias Comment [Name.Name] Type.Type
@@ -75,6 +79,17 @@ data Union = Union Comment [Name.Name] [(Name.Name, [Type.Type])]
 data Value = Value Comment Type.Type
 data Binop = Binop Comment Type.Type Binop.Associativity Binop.Precedence
 
+instance Show Alias where
+  show _ = "Alias"
+
+instance Show Union where
+  show _ = "Union"
+
+instance Show Value where
+  show _ = "Value"
+
+instance Show Binop where
+  show _ = "Binop"
 
 
 -- JSON

--- a/compiler/src/Elm/Float.hs
+++ b/compiler/src/Elm/Float.hs
@@ -24,6 +24,10 @@ type Float =
   Utf8.Utf8 ELM_FLOAT
 
 
+instance Show Float where
+  show = Utf8.toChars
+
+
 data ELM_FLOAT
 
 

--- a/compiler/src/Elm/Interface.hs
+++ b/compiler/src/Elm/Interface.hs
@@ -44,20 +44,20 @@ data Interface =
     , _aliases :: Map.Map Name.Name Alias
     , _binops  :: Map.Map Name.Name Binop
     }
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data Union
   = OpenUnion Can.Union
   | ClosedUnion Can.Union
   | PrivateUnion Can.Union
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data Alias
   = PublicAlias Can.Alias
   | PrivateAlias Can.Alias
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data Binop =
@@ -67,7 +67,7 @@ data Binop =
     , _op_associativity :: Binop.Associativity
     , _op_precedence :: Binop.Precedence
     }
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 

--- a/compiler/src/Elm/Interface.hs
+++ b/compiler/src/Elm/Interface.hs
@@ -16,6 +16,8 @@ module Elm.Interface
   )
   where
 
+import Debug.Trace
+
 
 import Control.Monad (liftM, liftM3, liftM4, liftM5)
 import Data.Binary
@@ -95,7 +97,7 @@ restrict exports dict =
 
 toOp :: Map.Map Name.Name Can.Annotation -> Can.Binop -> Binop
 toOp types (Can.Binop_ associativity precedence name) =
-  Binop name (types ! name) associativity precedence
+  Binop name (types ! (trace "toOp:" name)) associativity precedence
 
 
 restrictUnions :: Can.Exports -> Map.Map Name.Name Can.Union -> Map.Map Name.Name Union

--- a/compiler/src/Elm/Kernel.hs
+++ b/compiler/src/Elm/Kernel.hs
@@ -44,7 +44,7 @@ data Chunk
   | JsEnum Int
   | Debug
   | Prod
-
+  deriving (Show)
 
 
 -- COUNT FIELDS

--- a/compiler/src/Elm/Kernel.hs
+++ b/compiler/src/Elm/Kernel.hs
@@ -105,8 +105,8 @@ parser pkg foreigns =
 
 
 toError :: Row -> Col -> ()
-toError _ _ =
-  ()
+toError r c =
+  (traceStack (show ("Error parsing Kernel", r, c)) ())
 
 
 ignoreError :: a -> Row -> Col -> ()

--- a/compiler/src/Elm/Kernel.hs
+++ b/compiler/src/Elm/Kernel.hs
@@ -9,6 +9,9 @@ module Elm.Kernel
   where
 
 
+import Debug.Trace
+
+
 import Control.Monad (liftM, liftM2)
 import Data.Binary (Binary, get, put, getWord8, putWord8)
 import qualified Data.ByteString.Internal as B
@@ -82,7 +85,7 @@ type Foreigns =
 
 fromByteString :: Pkg.Name -> Foreigns -> B.ByteString -> Maybe Content
 fromByteString pkg foreigns bytes =
-  case P.fromByteString (parser pkg foreigns) toError bytes of
+  case P.fromByteString (parser pkg foreigns) toError (trace "zzz parsing Kernel JS" bytes) of
     Right content ->
       Just content
 

--- a/compiler/src/Elm/ModuleName.hs
+++ b/compiler/src/Elm/ModuleName.hs
@@ -133,6 +133,7 @@ data Canonical =
     { _package :: !Pkg.Name
     , _module :: !Name.Name
     }
+  deriving (Show)
 
 
 

--- a/compiler/src/Elm/Package.hs
+++ b/compiler/src/Elm/Package.hs
@@ -58,11 +58,17 @@ data Name =
     { _author :: !Author
     , _project :: !Project
     }
-    deriving (Ord)
+    deriving (Show, Ord)
 
 
 type Author = Utf8.Utf8 AUTHOR
 type Project = Utf8.Utf8 PROJECT
+
+instance Show Author where
+  show = Utf8.toChars
+
+instance Show Project where
+  show = Utf8.toChars
 
 data AUTHOR
 data PROJECT
@@ -82,7 +88,7 @@ data Canonical =
 
 isKernel :: Name -> Bool
 isKernel (Name author _) =
-  author == elm || author == elm_explorations
+  True
 
 
 toChars :: Name -> String

--- a/compiler/src/Elm/String.hs
+++ b/compiler/src/Elm/String.hs
@@ -30,6 +30,10 @@ type String =
   Utf8.Utf8 ELM_STRING
 
 
+instance Show String where
+  show = toChars
+
+
 data ELM_STRING
 
 

--- a/compiler/src/Generate/JavaScript/Expression.hs
+++ b/compiler/src/Generate/JavaScript/Expression.hs
@@ -11,6 +11,7 @@ module Generate.JavaScript.Expression
   )
   where
 
+import Debug.Trace
 
 import qualified Data.IntMap as IntMap
 import qualified Data.List as List
@@ -305,7 +306,7 @@ generateField mode name =
       JsName.fromLocal name
 
     Mode.Prod fields ->
-      fields ! name
+      fields ! (trace "generateField:" name)
 
 
 

--- a/compiler/src/Generate/JavaScript/Expression.hs
+++ b/compiler/src/Generate/JavaScript/Expression.hs
@@ -525,7 +525,7 @@ generateBasicsCall mode home name args =
             right = generateJsExpr mode elmRight
           in
           case name of
-            "add"  -> JS.Infix JS.OpAdd left right
+            "add"  -> JS.Infix JS.OpSub left right
             "sub"  -> JS.Infix JS.OpSub left right
             "mul"  -> JS.Infix JS.OpMul left right
             "fdiv" -> JS.Infix JS.OpDiv left right

--- a/compiler/src/Optimize/Case.hs
+++ b/compiler/src/Optimize/Case.hs
@@ -5,6 +5,9 @@ module Optimize.Case
   where
 
 
+import Debug.Trace
+
+
 import Control.Arrow (second)
 import qualified Data.Map as Map
 import Data.Map ((!))
@@ -129,7 +132,7 @@ createChoices
     -> (Int, Opt.Expr)
     -> ( (Int, Opt.Choice), Maybe (Int, Opt.Expr) )
 createChoices targetCounts (target, branch) =
-    if targetCounts ! target == 1 then
+    if targetCounts ! (trace ("target:"++show target) target) == 1 then
         ( (target, Opt.Inline branch)
         , Nothing
         )
@@ -151,7 +154,7 @@ insertChoices choiceDict decider =
   in
     case decider of
       Opt.Leaf target ->
-          Opt.Leaf (choiceDict ! target)
+          Opt.Leaf (choiceDict ! (trace ("insertChoices:"++show target) target))
 
       Opt.Chain testChain success failure ->
           Opt.Chain testChain (go success) (go failure)

--- a/compiler/src/Optimize/DecisionTree.hs
+++ b/compiler/src/Optimize/DecisionTree.hs
@@ -68,7 +68,7 @@ data DecisionTree
       , _edges :: [(Test, DecisionTree)]
       , _default :: Maybe DecisionTree
       }
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 data Test
@@ -80,14 +80,14 @@ data Test
   | IsChr ES.String
   | IsStr ES.String
   | IsBool Bool
-  deriving (Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 
 data Path
   = Index Index.ZeroBased Path
   | Unbox Path
   | Empty
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 

--- a/compiler/src/Optimize/Expression.hs
+++ b/compiler/src/Optimize/Expression.hs
@@ -26,7 +26,6 @@ import qualified Optimize.Names as Names
 import qualified Reporting.Annotation as A
 
 
-
 -- OPTIMIZE
 
 
@@ -47,7 +46,7 @@ optimize cycle (A.At region expression) =
         Names.registerGlobal home name
 
     Can.VarKernel home name ->
-      Names.registerKernel home True (Opt.VarKernel home name)
+      Names.registerKernel home (Name.isCoreMod home) (Opt.VarKernel home name)
 
     Can.VarForeign home name _ ->
       Names.registerGlobal home name

--- a/compiler/src/Optimize/Expression.hs
+++ b/compiler/src/Optimize/Expression.hs
@@ -8,6 +8,8 @@ module Optimize.Expression
   where
 
 
+import Debug.Trace
+
 import Prelude hiding (cycle)
 import Control.Monad (foldM)
 import qualified Data.Map as Map
@@ -34,7 +36,7 @@ type Cycle =
 
 optimize :: Cycle -> Can.Expr -> Names.Tracker Opt.Expr
 optimize cycle (A.At region expression) =
-  case expression of
+  case trace ("Expr: " ++ show expression) expression of
     Can.VarLocal name ->
       pure (Opt.VarLocal name)
 
@@ -45,7 +47,7 @@ optimize cycle (A.At region expression) =
         Names.registerGlobal home name
 
     Can.VarKernel home name ->
-      Names.registerKernel home (Opt.VarKernel home name)
+      Names.registerKernel home True (Opt.VarKernel home name)
 
     Can.VarForeign home name _ ->
       Names.registerGlobal home name
@@ -60,7 +62,7 @@ optimize cycle (A.At region expression) =
       Names.registerGlobal home name
 
     Can.Chr chr ->
-      Names.registerKernel Name.utils (Opt.Chr chr)
+      Names.registerKernel Name.utils False (Opt.Chr chr)
 
     Can.Str str ->
       pure (Opt.Str str)
@@ -72,7 +74,7 @@ optimize cycle (A.At region expression) =
       pure (Opt.Float float)
 
     Can.List entries ->
-      Names.registerKernel Name.list Opt.List
+      Names.registerKernel Name.list False Opt.List
         <*> traverse (optimize cycle) entries
 
     Can.Negate expr ->
@@ -162,10 +164,10 @@ optimize cycle (A.At region expression) =
         <*> traverse (optimize cycle) fields
 
     Can.Unit ->
-      Names.registerKernel Name.utils Opt.Unit
+      Names.registerKernel Name.utils False Opt.Unit
 
     Can.Tuple a b maybeC ->
-      Names.registerKernel Name.utils Opt.Tuple
+      Names.registerKernel Name.utils False Opt.Tuple
         <*> optimize cycle a
         <*> optimize cycle b
         <*> traverse (optimize cycle) maybeC

--- a/compiler/src/Optimize/Module.hs
+++ b/compiler/src/Optimize/Module.hs
@@ -43,11 +43,12 @@ type Annotations =
 
 optimize :: Annotations -> Can.Module -> Result i [W.Warning] Opt.LocalGraph
 optimize annotations (Can.Module home _ _ decls unions aliases _ effects) =
-  addDecls home annotations decls $
-    addEffects home effects $
-      addUnions home unions $
-        addAliases home aliases $
-          Opt.LocalGraph Nothing Map.empty Map.empty
+  addDecls (trace ("optimizzzzz" ++ show (annotations, home, decls, unions, aliases, effects)) home) annotations decls $
+    -- addKernel home chunks $
+      addEffects home effects $
+        addUnions home unions $
+          addAliases home aliases $
+            Opt.LocalGraph Nothing Map.empty Map.empty
 
 
 
@@ -170,6 +171,16 @@ addPort home name port_ graph =
       addToGraph (Opt.Global home name) node fields graph
 
 
+-- CORE MODULES
+
+-- addKernel :: ModuleName.Canonical -> Opt.LocalGraph -> [K.Chunk] -> Opt.LocalGraph
+-- addKernel home@(pkg shortName) chunks graph@(Opt.LocalGraph main nodes fields) =
+--   if Name.isCoreMod pkg then
+--       global = Opt.toKernelGlobal (traceShow ("addKernel13388", home) shortName) True
+--       node = Kernel chunks (foldr (Opt.addKernelDep True) Set.empty chunks)
+--       addToGraph (Opt.Global home global) node (K.countFields chunks) graph
+--     else
+--       graph
 
 -- HELPER
 
@@ -225,6 +236,8 @@ defToName def =
   case def of
     Can.Def (A.At _ name) _ _          -> name
     Can.TypedDef (A.At _ name) _ _ _ _ -> name
+
+
 
 
 

--- a/compiler/src/Optimize/Names.hs
+++ b/compiler/src/Optimize/Names.hs
@@ -15,6 +15,7 @@ module Optimize.Names
   )
   where
 
+import Debug.Trace
 
 import qualified Data.Map as Map
 import qualified Data.Name as Name
@@ -54,10 +55,10 @@ generate =
     ok (uid + 1) deps fields (Name.fromVarIndex uid)
 
 
-registerKernel :: Name.Name -> a -> Tracker a
-registerKernel home value =
+registerKernel :: Name.Name -> Bool -> a -> Tracker a
+registerKernel home isCoreMod value =
   Tracker $ \uid deps fields ok ->
-    ok uid (Set.insert (Opt.toKernelGlobal home) deps) fields value
+    ok uid (Set.insert (Opt.toKernelGlobal (trace ("registerKernel - home="++show home) home) isCoreMod) deps) fields value
 
 
 registerGlobal :: ModuleName.Canonical -> Name.Name -> Tracker Opt.Expr

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -45,6 +45,7 @@ fromByteString projectType source =
 data ProjectType
   = Package Pkg.Name
   | Application
+  deriving (Show)
 
 
 isCore :: ProjectType -> Bool

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -56,9 +56,7 @@ isCore projectType =
 
 isKernel :: ProjectType -> Bool
 isKernel projectType =
-  case projectType of
-    Package pkg -> Pkg.isKernel pkg
-    Application -> False
+  True
 
 
 

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -9,6 +9,8 @@ module Parse.Module
   )
   where
 
+import Debug.Trace
+
 
 import qualified Data.ByteString as BS
 import qualified Data.Name as Name
@@ -91,7 +93,7 @@ checkModule projectType (Module maybeHeader imports infixes decls) =
   let
     (values, unions, aliases, ports) = categorizeDecls [] [] [] [] decls
   in
-  case maybeHeader of
+  case (traceShow ("maybeHeaderzz", maybeHeader) maybeHeader) of
     Just (Header name effects exports docs) ->
       Src.Module (Just name) exports (toDocs docs decls) imports values unions aliases infixes
         <$> checkEffects projectType ports effects
@@ -242,12 +244,14 @@ chompModuleDocCommentSpace =
 
 data Header =
   Header (A.Located Name.Name) Effects (A.Located Src.Exposing) (Either A.Region Src.Comment)
+  deriving (Show)
 
 
 data Effects
   = NoEffects A.Region
   | Ports A.Region
   | Manager A.Region Src.Manager
+  deriving (Show)
 
 
 chompHeader :: Parser E.Module (Maybe Header)

--- a/compiler/src/Reporting/Annotation.hs
+++ b/compiler/src/Reporting/Annotation.hs
@@ -27,7 +27,7 @@ import Data.Word (Word16)
 
 data Located a =
   At Region a  -- PERF see if unpacking region is helpful
-
+  deriving (Show)
 
 instance Functor Located where
   fmap f (At region a) =
@@ -57,7 +57,7 @@ data Position =
   Position
     {-# UNPACK #-} !Word16
     {-# UNPACK #-} !Word16
-  deriving (Eq)
+  deriving (Eq, Show)
 
 
 at :: Position -> Position -> a -> Located a
@@ -70,7 +70,7 @@ at start end a =
 
 
 data Region = Region Position Position
-  deriving (Eq)
+  deriving (Show, Eq)
 
 
 toRegion :: Located a -> Region

--- a/compiler/src/Reporting/Error/Import.hs
+++ b/compiler/src/Reporting/Error/Import.hs
@@ -37,6 +37,7 @@ data Problem
   | Ambiguous FilePath [FilePath] Pkg.Name [Pkg.Name]
   | AmbiguousLocal FilePath FilePath [FilePath]
   | AmbiguousForeign Pkg.Name Pkg.Name [Pkg.Name]
+  deriving (Show)
 
 
 

--- a/compiler/src/Reporting/Error/Syntax.hs
+++ b/compiler/src/Reporting/Error/Syntax.hs
@@ -75,6 +75,9 @@ data Error
   | ParseError Module
 
 
+instance Show Error where
+  show e = "Error[TODO]"
+
 
 -- MODULE
 

--- a/compiler/src/Type/Instantiate.hs
+++ b/compiler/src/Type/Instantiate.hs
@@ -6,6 +6,8 @@ module Type.Instantiate
   )
   where
 
+import Debug.Trace
+
 
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict ((!))
@@ -36,7 +38,7 @@ fromSrcType freeVars sourceType =
         <*> fromSrcType freeVars result
 
     Can.TVar name ->
-      return (freeVars ! name)
+      return (freeVars ! (trace ("fromSrcType:"++Name.toChars name) name))
 
     Can.TType home name args ->
       AppN home name <$> traverse (fromSrcType freeVars) args
@@ -69,7 +71,7 @@ fromSrcType freeVars sourceType =
               return EmptyRecordN
 
             Just ext ->
-              return (freeVars ! ext)
+              return (freeVars ! (trace ("fromSrcType - TRecord:") ext))
 
 
 fromSrcFieldType :: Map.Map Name.Name Type -> Can.FieldType -> IO Type

--- a/compiler/src/Type/Solve.hs
+++ b/compiler/src/Type/Solve.hs
@@ -6,6 +6,8 @@ module Type.Solve
   where
 
 
+import Debug.Trace
+
 import Control.Monad
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict ((!))
@@ -97,7 +99,7 @@ solve env rank pools state constraint =
                       Error.typeReplace expectation expectedType
 
     CLocal region name expectation ->
-      do  actual <- makeCopy rank pools (env ! name)
+      do  actual <- makeCopy rank pools (env ! (trace ("CLocal:"++Name.toChars name) name))
           expected <- expectedToVariable rank pools expectation
           answer <- Unify.unify actual expected
           case answer of
@@ -456,7 +458,7 @@ typeToVar rank pools aliasDict tipe =
           register rank pools (Alias home name argVars aliasVar)
 
     PlaceHolder name ->
-      return (aliasDict ! name)
+      return (aliasDict ! (trace ("PlaceHolder:"++Name.toChars name) name))
 
     RecordN fields ext ->
       do  fieldVars <- traverse go fields
@@ -527,7 +529,7 @@ srcTypeToVar rank pools flexVars srcType =
           register rank pools (Structure (Fun1 argVar resultVar))
 
     Can.TVar name ->
-      return (flexVars ! name)
+      return (flexVars ! (trace ("Can.TVar"++Name.toChars name) name))
 
     Can.TType home name args ->
       do  argVars <- traverse go args
@@ -538,7 +540,7 @@ srcTypeToVar rank pools flexVars srcType =
           extVar <-
             case maybeExt of
               Nothing -> register rank pools emptyRecord1
-              Just ext -> return (flexVars ! ext)
+              Just ext -> return (flexVars ! (trace ("Can.TRecord:") ext))
           register rank pools (Structure (Record1 fieldVars extVar))
 
     Can.TUnit ->

--- a/elm.cabal
+++ b/elm.cabal
@@ -50,7 +50,7 @@ Executable elm
     if flag(dev)
         ghc-options: -O0 -Wall -Werror
     else
-        ghc-options: -O2 -rtsopts -threaded "-with-rtsopts=-N -qg -A128m"
+        ghc-options: -O0 -rtsopts -threaded "-with-rtsopts=-N -qg -A128m"
         -- add -eventlog for (elm make src/Main.elm +RTS -l; threadscope elm.eventlog)
         -- https://www.oreilly.com/library/view/parallel-and-concurrent/9781449335939/
 

--- a/terminal/src/Make.hs
+++ b/terminal/src/Make.hs
@@ -174,7 +174,7 @@ buildPaths style root details paths =
 
 
 getMains :: Build.Artifacts -> [ModuleName.Raw]
-getMains (Build.Artifacts _ _ roots modules) =
+getMains (Build.Artifacts _ _ roots modules _) =
   Maybe.mapMaybe (getMain modules) (NE.toList roots)
 
 
@@ -207,7 +207,7 @@ isMain targetName modul =
 
 
 hasOneMain :: Build.Artifacts -> Task ModuleName.Raw
-hasOneMain (Build.Artifacts _ _ roots modules) =
+hasOneMain (Build.Artifacts _ _ roots modules _) =
   case roots of
     NE.List root [] -> Task.mio Exit.MakeNoMain (return $ getMain modules root)
     NE.List _ (_:_) -> Task.throw Exit.MakeMultipleFilesIntoHtml
@@ -218,7 +218,7 @@ hasOneMain (Build.Artifacts _ _ roots modules) =
 
 
 getNoMains :: Build.Artifacts -> [ModuleName.Raw]
-getNoMains (Build.Artifacts _ _ roots modules) =
+getNoMains (Build.Artifacts _ _ roots modules _) =
   Maybe.mapMaybe (getNoMain modules) (NE.toList roots)
 
 


### PR DESCRIPTION
This patch adds debugging comments _everywhere_ as a simple approach to get a better understanding how things work. Specifically, we're trying to debug where/how the `Elm.Kernel.Http`-style code decides to load `src/elm/kernel/http.js`. I have a lot of leads, but it's falling short somewhere in the load module recursive loop that's not entirely obvious in its function. This goes hand-in-hand with the Core Mod branch of [Ketchum](https://github.com/ash-lng/ketchum/pull/2) which tries to create a core mod.

A few notes:

1. We call them `AshCoreMod` since it needs to be the same number of letters as `Elm.Kernel` and that happened to work out.
2. The current issue is that you can basically run `elm comile src/Main.elm` in Ketchum and it says "1 module compiled successfully!" but then crashes on some later step, which I assume is the step that tries to link everything together and generate the JavaScript output. Not entirely sure, hence all of the deep debugging messages.
3. I'm not sure if "hack any JavaScript" is right-- and I might say let's just use the newer, less hacky variant of "effect modules" -- this might involve less hacks, but I wanted to get an understand of what it would take to allow us to write _any_ kernel code, not just effect modules (which can emit custom `Cmd`s and `Sub`s not through ports, but are similarly restricted to only being from the Elm team)
4. We drop optimizations to zero, which saves a lot of build time (though it's still not fast, by any means)